### PR TITLE
Fixed ash crate version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.14"
 env_logger = "0.9.0"
-ash = { version= "0.35.1", default-features = false, features = ["linked", "debug"] }
+ash = { version= "0.36.0", default-features = false, features = ["linked", "debug"] }
 ash-window = "0.9.0"
 winit = "0.26.1"
 winit_input_helper = "0.11.0"


### PR DESCRIPTION
There was a version mismatch with the project's `ash` crate version (0.35.1) with`ash-window`'s internal `ash` crate dependency (0.36.0) .

Version mismatch noted thanks to `cargo tree`.